### PR TITLE
Update GitHub organization name to NID-kt

### DIFF
--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -8,7 +8,7 @@ const createGitHubApiHeaders = () => {
 
 export const isJoinedOrganization = async (username: string) => {
   const response = await fetch(
-    `https://api.github.com/orgs/NID-roid/members/${username}`,
+    `https://api.github.com/orgs/NID-kt/members/${username}`,
     {
       headers: createGitHubApiHeaders(),
     },
@@ -18,7 +18,7 @@ export const isJoinedOrganization = async (username: string) => {
 
 export const createOrganizationInvitation = async (userID: number) => {
   const response = await fetch(
-    'https://api.github.com/orgs/NID-roid/invitations',
+    'https://api.github.com/orgs/NID-kt/invitations',
     {
       method: 'POST',
       headers: createGitHubApiHeaders(),


### PR DESCRIPTION
This pull request updates the GitHub organization name from "NID-roid" to "NID-kt" in the `github.ts` file. This change ensures that the correct organization is used when checking if a user has joined the organization and when creating organization invitations.