### PR TITLE
Add redirect for /event/lt-vol-3 in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,12 @@
       "has": [{ "type": "host", "value": "discord.nidkt.org" }],
       "destination": "https://discord.gg/nid-kt",
       "permanent": true
+    },
+    {
+      "source": "/event/lt-vol-3",
+      "has": [{ "type": "host", "value": "discord.nidkt.org" }],
+      "destination": "https://discord.gg/nid-kt?event=1260990331193917541",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
This pull request adds a redirect for the "/event/lt-vol-3" path in the "vercel.json" file. The redirect will send users to "https://discord.gg/nid-kt?event=1260990331193917541" when they visit that path.