### PR TITLE
Update .husky/pre-commit to use lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm lint-staged
+lint-staged


### PR DESCRIPTION
This pull request updates the .husky/pre-commit file to use lint-staged instead of pnpm lint-staged. This change improves the linting process and ensures consistency in the codebase.